### PR TITLE
Fix black formatting in on_message.py

### DIFF
--- a/hooverbot/handlers/events/on_message.py
+++ b/hooverbot/handlers/events/on_message.py
@@ -17,7 +17,7 @@ class OnMessage(Handler):
         self.msg = message
 
     def match_response(self):
-        match self.msg.content.lower().replace(' ', ''):
+        match self.msg.content.lower().replace(" ", ""):
             case "$hello":
                 return "Hello!"
             case s if "tebow" in s:


### PR DESCRIPTION
## Summary
- `black --check` was failing in the deploy workflow on `hooverbot/handlers/events/on_message.py` — a single-quoted string in `match_response`.
- Ran `black`, which normalizes it to double quotes. One-line change.

## Verification
- `poetry run black --check .` → all 12 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)